### PR TITLE
Fix use prefix routing that change structure directory happened `class does not exits`.

### DIFF
--- a/src/Controller/Component/AclManagerComponent.php
+++ b/src/Controller/Component/AclManagerComponent.php
@@ -289,6 +289,7 @@ class AclManagerComponent extends Component
             $controller = str_replace(App::path('Controller'), '', $file);
             $controller = explode('.', $controller)[0];
             $controller = str_replace('Controller', '', $controller);
+            $controller = str_replace(DS, '\\', $controller);
             array_push($results, $controller);
 
         }


### PR DESCRIPTION
I use prefix routing and change Controller directory. It is not be detected by CakePHP.

Then, did happened error "class does not exits".

I make directory `src/Controller/Admin`, and class file `src/Controller/Admin/UsersController.php`.

Error message:
"Class App\Controller\Admin/UsersController does not exist"

So, I fixed that added one line code for `src/Controller/Component/AclManagerComponent.php`:292 line.

```php
<?php
// ...
    private function __getControllers()
    {
        $path = App::path('Controller');
        $dir = new Folder($path[0]);
        $files = $dir->findRecursive('.*Controller\.php');
        $results = [];
        foreach ($files as $file) {
            $controller = str_replace(App::path('Controller'), '', $file);
            $controller = explode('.', $controller)[0];
            $controller = str_replace('Controller', '', $controller);
            $controller = str_replace(DS, '\\', $controller); // added line.
            array_push($results, $controller);

        }
        return $results;
    }
// ...
```

Is not this code problem? If no problem, please merge this pull request.